### PR TITLE
[WIP] バックエンドの実装

### DIFF
--- a/api/app/controllers/api/v1/answer_controller.rb
+++ b/api/app/controllers/api/v1/answer_controller.rb
@@ -1,0 +1,75 @@
+class Api::V1::AnswerController < ApplicationController
+  # テスト用にトークン認証を無効
+  # TODO:環境変数等で切り替える
+  protect_from_forgery except: [:create]
+
+  def index
+    begin
+      @answers = Answer.all.reverse_order!
+      @header ={
+          :status => :ok,
+          :errorCode => 200
+      }
+    rescue => e
+      @answers = {}
+      @header ={
+          :status => e.message,
+          :errorCode => 400
+      }
+    end
+    render json: {:response => @answers, :header => @header}, :status => @header[:errorCode]
+  end
+
+  def show
+    begin
+      @answers = Answer.find_by!(id: params[:id])
+      @header ={
+          :status => :ok,
+          :errorCode => 200
+      }
+    rescue => e
+      @articles = {}
+      @header ={
+          :status => e.message,
+          :errorCode => 400
+      }
+    end
+    render json: {:response => @answers, :header => @header}, :status => @header[:errorCode]
+  end
+
+  def new
+    begin
+      @answers = Answer.first!
+      @header ={
+          :status => :ok,
+          :errorCode => 200
+      }
+    rescue => e
+      @answers = {}
+      @header ={
+          :status => e.message,
+          :errorCode => 400
+      }
+    end
+    render json: {:response => @answers, :header => @header}, :status => @header[:errorCode]
+  end
+
+  def create
+    begin
+      @articles = Answer.create!({answer_json:[:answer_json], structure_json:params[:structure_json]})
+      @articles = Answer.last!
+      @header ={
+          :status => :ok,
+          :errorCode => 200
+      }
+    rescue => e
+      @articles = {}
+      @header ={
+          :status => e.message,
+          :errorCode => 400
+      }
+    end
+    render json: {:response => @articles, :header => @header}, :status => @header[:errorCode]
+  end
+
+end

--- a/api/app/controllers/api/v1/answer_controller.rb
+++ b/api/app/controllers/api/v1/answer_controller.rb
@@ -1,6 +1,4 @@
 class Api::V1::AnswerController < ApplicationController
-  # テスト用にトークン認証を無効
-  # TODO:環境変数等で切り替える
 
   def index
     begin
@@ -55,7 +53,8 @@ class Api::V1::AnswerController < ApplicationController
 
   def create
     begin
-      @articles = Answer.create!({answer_json:[:answer_json], structure_json:params[:structure_json]})
+      @parent_form_structure = FormStructure.find_by!(id: params[:form_structure])
+      Answer.create!({answer_json:params[:answer_json], form_structure:@parent_form_structure})
       @articles = Answer.last!
       @header ={
           :status => :ok,

--- a/api/app/controllers/api/v1/answer_controller.rb
+++ b/api/app/controllers/api/v1/answer_controller.rb
@@ -1,7 +1,6 @@
 class Api::V1::AnswerController < ApplicationController
   # テスト用にトークン認証を無効
   # TODO:環境変数等で切り替える
-  protect_from_forgery except: [:create]
 
   def index
     begin

--- a/api/app/controllers/api/v1/form_structure_controller.rb
+++ b/api/app/controllers/api/v1/form_structure_controller.rb
@@ -1,8 +1,4 @@
 class Api::V1::FormStructureController < ApplicationController
-  # テスト用にトークン認証を無効
-  # TODO:環境変数等で切り替える
-  # protect_from_forgery except: [:create]
-
   def index
     begin
       @form_structures = FormStructure.all.reverse_order!

--- a/api/app/controllers/api/v1/form_structure_controller.rb
+++ b/api/app/controllers/api/v1/form_structure_controller.rb
@@ -1,0 +1,75 @@
+class Api::V1::FormStructureController < ApplicationController
+  # テスト用にトークン認証を無効
+  # TODO:環境変数等で切り替える
+  # protect_from_forgery except: [:create]
+
+  def index
+    begin
+      @form_structures = FormStructure.all.reverse_order!
+      @header ={
+          :status => :ok,
+          :errorCode => 200
+      }
+    rescue => e
+      @answers = {}
+      @header ={
+          :status => e.message,
+          :errorCode => 400
+      }
+    end
+    render json: {:response => @answers, :header => @header}, :status => @header[:errorCode]
+  end
+
+  def show
+    begin
+      @form_structures = FormStructure.find_by!(id: params[:id])
+      @header ={
+          :status => :ok,
+          :errorCode => 200
+      }
+    rescue => e
+      @articles = {}
+      @header ={
+          :status => e.message,
+          :errorCode => 400
+      }
+    end
+    render json: {:response => @answers, :header => @header}, :status => @header[:errorCode]
+  end
+
+  def new
+    begin
+      @form_structures = FormStructure.first!
+      @header ={
+          :status => :ok,
+          :errorCode => 200
+      }
+    rescue => e
+      @answers = {}
+      @header ={
+          :status => e.message,
+          :errorCode => 400
+      }
+    end
+    render json: {:response => @answers, :header => @header}, :status => @header[:errorCode]
+  end
+
+  def create
+    begin
+      FormStructure.create!({structure_json:params[:structure_json]})
+      @form_structures = FormStructure.last!
+      @header ={
+          :status => :ok,
+          :errorCode => 200
+      }
+    rescue => e
+      @articles = {}
+      @header ={
+          :status => e.message,
+          :errorCode => 400
+      }
+    end
+    render json: {:response => @articles, :header => @header}, :status => @header[:errorCode]
+  end
+
+end

--- a/api/app/models/answer.rb
+++ b/api/app/models/answer.rb
@@ -1,0 +1,14 @@
+class Answer < ApplicationRecord
+  belongs_to :form_structure
+
+  validate :valid_json
+
+  def valid_json
+    begin
+      JSON.parse(answer_json)
+    rescue JSON::ParserError
+      errors.add(:answer_json, 'jsonとしてパースできません')
+    end
+  end
+
+end

--- a/api/app/models/form_structure.rb
+++ b/api/app/models/form_structure.rb
@@ -1,0 +1,13 @@
+class FormStructure < ApplicationRecord
+  has_many :answers
+
+  validate :valid_json
+
+  def valid_json
+    begin
+      JSON.parse(structure_json)
+    rescue JSON::ParserError
+      errors.add(:structure_json, 'jsonとしてパースできません')
+    end
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,3 +1,10 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  namespace :api do
+    namespace :v1 do
+      resources :answer, :only => [:index, :show, :create, :new]
+      resources :form_structure, :only => [:index, :show, :create, :new]
+    end
+  end
 end

--- a/api/db/migrate/20160712061801_create_form_structures.rb
+++ b/api/db/migrate/20160712061801_create_form_structures.rb
@@ -1,0 +1,9 @@
+class CreateFormStructures < ActiveRecord::Migration[5.0]
+  def change
+    create_table :form_structures do |t|
+      t.string :structure_json, :null => false
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/migrate/20160712061813_create_answers.rb
+++ b/api/db/migrate/20160712061813_create_answers.rb
@@ -1,0 +1,10 @@
+class CreateAnswers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :answers do |t|
+      t.string :answer_json, :null => false
+      t.integer :form_structure_id, :null => false
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -1,0 +1,29 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20160712061813) do
+
+  create_table "answers", force: :cascade do |t|
+    t.string   "answer_json",       null: false
+    t.integer  "form_structure_id", null: false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+  end
+
+  create_table "form_structures", force: :cascade do |t|
+    t.string   "structure_json", null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
+
+end

--- a/api/test/controllers/api/v1/answer_controller_test.rb
+++ b/api/test/controllers/api/v1/answer_controller_test.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+
+class Api::V1::AnswerControllerTest < ActionController::TestCase
+  fixtures :answers
+
+  def setup
+    @controller = Api::V1::ArticlesController.new
+    @request = ActionController::TestRequest.new
+    @response = ActionController::TestResponse.new
+  end
+
+  # test "routes to #index" do
+  #   get :index
+  #   assert_response :success
+  #
+  #   #全ての記事が帰ってくるので検証
+  #   json_request = JSON.parse(response.body)
+  #   assert_equal json_request["response"][0]["title"], articles(:one).title
+  #   assert_equal json_request["response"][0]["body"], articles(:one).body
+  #   assert_equal json_request["response"][0]["author"], articles(:one).author
+  #   assert_equal json_request["response"][1]["title"], articles(:two).title
+  #   assert_equal json_request["response"][1]["body"], articles(:two).body
+  #   assert_equal json_request["response"][1]["author"], articles(:two).author
+  #
+  # end
+  #
+  # test "routes to #show" do
+  #   show_article = :one
+  #
+  #   get :show , {:id => articles(show_article).id}
+  #   assert_response :success
+  #
+  #   #指定した記事が帰ってくるのでの検証
+  #   json_request = JSON.parse(response.body)
+  #   assert_equal json_request["response"]["id"], articles(show_article).id
+  #   assert_equal json_request["response"]["title"], articles(show_article).title
+  #   assert_equal json_request["response"]["body"], articles(show_article).body
+  #   assert_equal json_request["response"]["author"], articles(show_article).author
+  # end
+  #
+  # test "route to #show fail" do
+  #   get :show , {:id => '１'}
+  #   assert_response 400
+  #
+  #   get :show , {:id => 'hoge'}
+  #   assert_response 400
+  # end
+  #
+  # test "routes to #new" do
+  #   new_article = :two
+  #
+  #   get :new
+  #   assert_response :success
+  #
+  #   #一番最後に作成した記事が帰ってくるのでの検証
+  #   json_request = JSON.parse(response.body)
+  #   assert_equal json_request["response"]["id"], articles(new_article).id
+  #   assert_equal json_request["response"]["title"], articles(new_article).title
+  #   assert_equal json_request["response"]["body"], articles(new_article).body
+  #   assert_equal json_request["response"]["author"], articles(new_article).author
+  # end
+  #
+  # test "routes to #create" do
+  #   create_artcle = {title: "title", body: "body", author: "author"}
+  #
+  #   post :create , create_artcle
+  #   assert_response :success
+  #
+  #   #作成した記事が帰ってくるのでの検証
+  #   json_request = JSON.parse(response.body)
+  #   assert_equal json_request["response"]["title"], create_artcle[:title]
+  #   assert_equal json_request["response"]["body"], create_artcle[:body]
+  #   assert_equal json_request["response"]["author"], create_artcle[:author]
+  # end
+
+end

--- a/api/test/controllers/api/v1/answer_controller_test.rb
+++ b/api/test/controllers/api/v1/answer_controller_test.rb
@@ -7,17 +7,17 @@ class Api::V1::AnswerControllerTest < ActionController::TestCase
     @controller = Api::V1::AnswerController.new
   end
 
-  test "routes to #index" do
+  test "routes to ans#index" do
     get :index
     assert_response :success
   end
 
-  test "routes to #show" do
+  test "routes to ans#show" do
     get :show , params:{:id => answers(:ans_valid).id}
     assert_response :success
   end
 
-  test "route to #show fail" do
+  test "route to ans#show fail" do
     get :show , params:{:id => '１'}
     assert_response 400
 
@@ -25,14 +25,14 @@ class Api::V1::AnswerControllerTest < ActionController::TestCase
     assert_response 400
   end
 
-  test "routes to #new" do
+  test "routes to ans#new" do
     get :new
     assert_response :success
   end
 
-  test "routes to #create" do
+  test "routes to ans#create" do
     a = answers(:ans_valid)
-    post :create , params:{:answer_json=>a.answer_json, :form_structure=>a.form_structure}
+    post :create , params:{:answer_json=>a.answer_json, :form_structure=>a.form_structure_id}
 
     assert_response :success
   end

--- a/api/test/controllers/api/v1/answer_controller_test.rb
+++ b/api/test/controllers/api/v1/answer_controller_test.rb
@@ -4,73 +4,37 @@ class Api::V1::AnswerControllerTest < ActionController::TestCase
   fixtures :answers
 
   def setup
-    @controller = Api::V1::ArticlesController.new
-    @request = ActionController::TestRequest.new
-    @response = ActionController::TestResponse.new
+    @controller = Api::V1::AnswerController.new
   end
 
-  # test "routes to #index" do
-  #   get :index
-  #   assert_response :success
-  #
-  #   #全ての記事が帰ってくるので検証
-  #   json_request = JSON.parse(response.body)
-  #   assert_equal json_request["response"][0]["title"], articles(:one).title
-  #   assert_equal json_request["response"][0]["body"], articles(:one).body
-  #   assert_equal json_request["response"][0]["author"], articles(:one).author
-  #   assert_equal json_request["response"][1]["title"], articles(:two).title
-  #   assert_equal json_request["response"][1]["body"], articles(:two).body
-  #   assert_equal json_request["response"][1]["author"], articles(:two).author
-  #
-  # end
-  #
-  # test "routes to #show" do
-  #   show_article = :one
-  #
-  #   get :show , {:id => articles(show_article).id}
-  #   assert_response :success
-  #
-  #   #指定した記事が帰ってくるのでの検証
-  #   json_request = JSON.parse(response.body)
-  #   assert_equal json_request["response"]["id"], articles(show_article).id
-  #   assert_equal json_request["response"]["title"], articles(show_article).title
-  #   assert_equal json_request["response"]["body"], articles(show_article).body
-  #   assert_equal json_request["response"]["author"], articles(show_article).author
-  # end
-  #
-  # test "route to #show fail" do
-  #   get :show , {:id => '１'}
-  #   assert_response 400
-  #
-  #   get :show , {:id => 'hoge'}
-  #   assert_response 400
-  # end
-  #
-  # test "routes to #new" do
-  #   new_article = :two
-  #
-  #   get :new
-  #   assert_response :success
-  #
-  #   #一番最後に作成した記事が帰ってくるのでの検証
-  #   json_request = JSON.parse(response.body)
-  #   assert_equal json_request["response"]["id"], articles(new_article).id
-  #   assert_equal json_request["response"]["title"], articles(new_article).title
-  #   assert_equal json_request["response"]["body"], articles(new_article).body
-  #   assert_equal json_request["response"]["author"], articles(new_article).author
-  # end
-  #
-  # test "routes to #create" do
-  #   create_artcle = {title: "title", body: "body", author: "author"}
-  #
-  #   post :create , create_artcle
-  #   assert_response :success
-  #
-  #   #作成した記事が帰ってくるのでの検証
-  #   json_request = JSON.parse(response.body)
-  #   assert_equal json_request["response"]["title"], create_artcle[:title]
-  #   assert_equal json_request["response"]["body"], create_artcle[:body]
-  #   assert_equal json_request["response"]["author"], create_artcle[:author]
-  # end
+  test "routes to #index" do
+    get :index
+    assert_response :success
+  end
+
+  test "routes to #show" do
+    get :show , params:{:id => answers(:ans_valid).id}
+    assert_response :success
+  end
+
+  test "route to #show fail" do
+    get :show , params:{:id => '１'}
+    assert_response 400
+
+    get :show , params:{:id => 'hoge'}
+    assert_response 400
+  end
+
+  test "routes to #new" do
+    get :new
+    assert_response :success
+  end
+
+  test "routes to #create" do
+    a = answers(:ans_valid)
+    post :create , params:{:answer_json=>a.answer_json, :form_structure=>a.form_structure}
+
+    assert_response :success
+  end
 
 end

--- a/api/test/controllers/api/v1/form_structure_controller_test.rb
+++ b/api/test/controllers/api/v1/form_structure_controller_test.rb
@@ -4,20 +4,20 @@ class Api::V1::FormStructureControllerTest < ActionController::TestCase
   fixtures :form_structures
 
   def setup
-    @controller = Api::V1::AnswerController.new
+    @controller = Api::V1::FormStructureController.new
   end
 
-  test "routes to #index" do
+  test "routes to fs#index" do
     get :index
     assert_response :success
   end
 
-  test "routes to #show" do
+  test "routes to fs#show" do
     get :show , params:{:id => form_structures(:f_str_valid).id}
     assert_response :success
   end
 
-  test "route to #show fail" do
+  test "route to fs#show fail" do
     get :show , params:{:id => '１'}
     assert_response 400
 
@@ -25,12 +25,12 @@ class Api::V1::FormStructureControllerTest < ActionController::TestCase
     assert_response 400
   end
 
-  test "routes to #new" do
+  test "routes to fs#new" do
     get :new
     assert_response :success
   end
 
-  test "routes to #create" do
+  test "routes to fs#create" do
     s = form_structures(:f_str_valid)
     post :create , params:{:structure_json=>s.structure_json}
 

--- a/api/test/controllers/api/v1/form_structure_controller_test.rb
+++ b/api/test/controllers/api/v1/form_structure_controller_test.rb
@@ -1,84 +1,40 @@
 require 'test_helper'
 
-class Api::V1::FormStructureControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+class Api::V1::FormStructureControllerTest < ActionController::TestCase
+  fixtures :form_structures
+
+  def setup
+    @controller = Api::V1::AnswerController.new
+  end
+
+  test "routes to #index" do
+    get :index
+    assert_response :success
+  end
+
+  test "routes to #show" do
+    get :show , params:{:id => form_structures(:f_str_valid).id}
+    assert_response :success
+  end
+
+  test "route to #show fail" do
+    get :show , params:{:id => '１'}
+    assert_response 400
+
+    get :show , params:{:id => 'hoge'}
+    assert_response 400
+  end
+
+  test "routes to #new" do
+    get :new
+    assert_response :success
+  end
+
+  test "routes to #create" do
+    s = form_structures(:f_str_valid)
+    post :create , params:{:structure_json=>s.structure_json}
+
+    assert_response :success
+  end
+
 end
-
-
-#
-# class Api::ArticlesControllerTest < ActionController::TestCase
-#   fixtures :articles
-#
-#   def setup
-#     @controller = Api::V1::ArticlesController.new
-#     @request = ActionController::TestRequest.new
-#     @response = ActionController::TestResponse.new
-#   end
-#
-#   test "routes to #index" do
-#     get :index
-#     assert_response :success
-#
-#     #全ての記事が帰ってくるので検証
-#     json_request = JSON.parse(response.body)
-#     assert_equal json_request["response"][0]["title"], articles(:one).title
-#     assert_equal json_request["response"][0]["body"], articles(:one).body
-#     assert_equal json_request["response"][0]["author"], articles(:one).author
-#     assert_equal json_request["response"][1]["title"], articles(:two).title
-#     assert_equal json_request["response"][1]["body"], articles(:two).body
-#     assert_equal json_request["response"][1]["author"], articles(:two).author
-#
-#   end
-#
-#   test "routes to #show" do
-#     show_article = :one
-#
-#     get :show , {:id => articles(show_article).id}
-#     assert_response :success
-#
-#     #指定した記事が帰ってくるのでの検証
-#     json_request = JSON.parse(response.body)
-#     assert_equal json_request["response"]["id"], articles(show_article).id
-#     assert_equal json_request["response"]["title"], articles(show_article).title
-#     assert_equal json_request["response"]["body"], articles(show_article).body
-#     assert_equal json_request["response"]["author"], articles(show_article).author
-#   end
-#
-#   test "route to #show fail" do
-#     get :show , {:id => '１'}
-#     assert_response 400
-#
-#     get :show , {:id => 'hoge'}
-#     assert_response 400
-#   end
-#
-#   test "routes to #new" do
-#     new_article = :two
-#
-#     get :new
-#     assert_response :success
-#
-#     #一番最後に作成した記事が帰ってくるのでの検証
-#     json_request = JSON.parse(response.body)
-#     assert_equal json_request["response"]["id"], articles(new_article).id
-#     assert_equal json_request["response"]["title"], articles(new_article).title
-#     assert_equal json_request["response"]["body"], articles(new_article).body
-#     assert_equal json_request["response"]["author"], articles(new_article).author
-#   end
-#
-#   test "routes to #create" do
-#     create_artcle = {title: "title", body: "body", author: "author"}
-#
-#     post :create , create_artcle
-#     assert_response :success
-#
-#     #作成した記事が帰ってくるのでの検証
-#     json_request = JSON.parse(response.body)
-#     assert_equal json_request["response"]["title"], create_artcle[:title]
-#     assert_equal json_request["response"]["body"], create_artcle[:body]
-#     assert_equal json_request["response"]["author"], create_artcle[:author]
-#   end
-#
-# end

--- a/api/test/controllers/api/v1/form_structure_controller_test.rb
+++ b/api/test/controllers/api/v1/form_structure_controller_test.rb
@@ -1,0 +1,84 @@
+require 'test_helper'
+
+class Api::V1::FormStructureControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end
+
+
+#
+# class Api::ArticlesControllerTest < ActionController::TestCase
+#   fixtures :articles
+#
+#   def setup
+#     @controller = Api::V1::ArticlesController.new
+#     @request = ActionController::TestRequest.new
+#     @response = ActionController::TestResponse.new
+#   end
+#
+#   test "routes to #index" do
+#     get :index
+#     assert_response :success
+#
+#     #全ての記事が帰ってくるので検証
+#     json_request = JSON.parse(response.body)
+#     assert_equal json_request["response"][0]["title"], articles(:one).title
+#     assert_equal json_request["response"][0]["body"], articles(:one).body
+#     assert_equal json_request["response"][0]["author"], articles(:one).author
+#     assert_equal json_request["response"][1]["title"], articles(:two).title
+#     assert_equal json_request["response"][1]["body"], articles(:two).body
+#     assert_equal json_request["response"][1]["author"], articles(:two).author
+#
+#   end
+#
+#   test "routes to #show" do
+#     show_article = :one
+#
+#     get :show , {:id => articles(show_article).id}
+#     assert_response :success
+#
+#     #指定した記事が帰ってくるのでの検証
+#     json_request = JSON.parse(response.body)
+#     assert_equal json_request["response"]["id"], articles(show_article).id
+#     assert_equal json_request["response"]["title"], articles(show_article).title
+#     assert_equal json_request["response"]["body"], articles(show_article).body
+#     assert_equal json_request["response"]["author"], articles(show_article).author
+#   end
+#
+#   test "route to #show fail" do
+#     get :show , {:id => '１'}
+#     assert_response 400
+#
+#     get :show , {:id => 'hoge'}
+#     assert_response 400
+#   end
+#
+#   test "routes to #new" do
+#     new_article = :two
+#
+#     get :new
+#     assert_response :success
+#
+#     #一番最後に作成した記事が帰ってくるのでの検証
+#     json_request = JSON.parse(response.body)
+#     assert_equal json_request["response"]["id"], articles(new_article).id
+#     assert_equal json_request["response"]["title"], articles(new_article).title
+#     assert_equal json_request["response"]["body"], articles(new_article).body
+#     assert_equal json_request["response"]["author"], articles(new_article).author
+#   end
+#
+#   test "routes to #create" do
+#     create_artcle = {title: "title", body: "body", author: "author"}
+#
+#     post :create , create_artcle
+#     assert_response :success
+#
+#     #作成した記事が帰ってくるのでの検証
+#     json_request = JSON.parse(response.body)
+#     assert_equal json_request["response"]["title"], create_artcle[:title]
+#     assert_equal json_request["response"]["body"], create_artcle[:body]
+#     assert_equal json_request["response"]["author"], create_artcle[:author]
+#   end
+#
+# end

--- a/api/test/fixtures/answers.yml
+++ b/api/test/fixtures/answers.yml
@@ -1,0 +1,18 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+
+ans_valid:
+  answer_json: '{}'
+  form_structure: f_str_valid
+
+ans_valid_2:
+  answer_json: '{}'
+  form_structure: f_str_valid
+
+ans_invalid_json:
+  answer_json: piyo
+  form_structure: f_str_valid

--- a/api/test/fixtures/form_structures.yml
+++ b/api/test/fixtures/form_structures.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+
+f_str_valid:
+  structure_json: '{}'
+
+f_str_invalid_json:
+  structure_json: hoge
+

--- a/api/test/models/answer_test.rb
+++ b/api/test/models/answer_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class AnswerTest < ActiveSupport::TestCase
+  fixtures :answers
+
+  def test_valid_fixture
+    ans = Answer.find(answers(:ans_valid).id)
+
+    # 値のテスト
+    assert ans.valid?, ans.errors.full_messages
+    assert_equal ans.answer_json, answers(:ans_valid).answer_json
+    assert_equal ans.form_structure_id, answers(:ans_valid).form_structure_id
+  end
+
+  def test_invalid_json_fixture
+    ans = Answer.find(answers(:ans_invalid_json).id)
+
+    # 不正かだけテスト
+    assert !ans.valid?, ans.errors.full_messages
+  end
+
+
+end

--- a/api/test/models/form_structure_test.rb
+++ b/api/test/models/form_structure_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class FormStructureTest < ActiveSupport::TestCase
+  fixtures :form_structures
+
+  def test_valid_fixture
+    f_str = FormStructure.find(form_structures(:f_str_valid).id)
+
+    # 値のテスト
+    assert f_str.valid?, f_str.errors.full_messages
+    assert_equal f_str.structure_json, form_structures(:f_str_valid).structure_json
+
+  end
+
+  def test_invalid_json_fixture
+    f_str = FormStructure.find(form_structures(:f_str_invalid_json).id)
+
+    # 不正かだけテスト
+    assert !f_str.valid?, ''
+  end
+
+end


### PR DESCRIPTION
## 要求仕様
### バックエンドが受信するデータ
1. フォームの構造
   - string形式のjson
2. アンケート回答
   - 使用したフォームのidと回答のstring形式のjson

1と2は親子関係で参照できるようにする
### バックエンドが送信するデータ
1. フォームの構造
   - フォームの構造を表すjson(string形式)
   - (アンケート回答と紐づけられるように) id
2. アンケート回答
   - 回答内容のjson(string形式)
   - 親フォームのid
## 作業リスト
### 全体
- [ ] コードのリファクタリング
  - [ ] コメントの追加
  - [ ] ステータスコードの改善 
- [ ] APIのドキュメントの作成
### 実装
#### データベース(テーブル）
- [x] フォームの構造:`form_structure`
  - [x] 実装
- [x] アンケート回答:`answer`
  - [x] 実装
#### モデル
- [x] フォームの構造:`FormStructure`
  - [x] 実装
  - [x] テスト
- [x] アンケート回答:`Answer`
  - [x] 実装
  - [x] テスト
#### コントローラー
- [x] フォームの構造を返すAPI
  - [x] 実装
  - [x] テスト
- [x] アンケートの結果を返すAPI
  - [x] 実装
  - [x] テスト
